### PR TITLE
Integrate BattleTalk dialogue polling

### DIFF
--- a/UPDATE-TEST-CHECKLIST.md
+++ b/UPDATE-TEST-CHECKLIST.md
@@ -236,7 +236,7 @@ Sharlayan upstream smoke는 IronworksTranslator의 release readiness를 대신�
 
 Package and resource checks:
 
-- [ ] Restore 결과와 publish 산출물이 `Sharlayan.Lite 9.1.4`를 사용한다.
+- [ ] Restore 결과와 publish 산출물이 `Sharlayan.Lite 9.2.0`을 사용한다.
 - [ ] Publish 및 Velopack package에 `FFXIVClientStructs`, `HermesAddress`,
   `latest/address.json`, local `address.json` 또는 `UseInternalAddress` consumer가 없다.
 - [ ] 새 Hermes cache에서 앱을 시작하면 `RemotePreferred`가 remote

--- a/docs/agent-log/2026-07-26/2026-07-26-battletalk-talksubtitle-support-investigation.md
+++ b/docs/agent-log/2026-07-26/2026-07-26-battletalk-talksubtitle-support-investigation.md
@@ -2,6 +2,73 @@
 
 작성일: 2026-07-26
 
+## 0. 2026-07-26 구현 진행 업데이트
+
+사용자 결정으로 두 기능을 같은 release에 포함하는 구현을 시작했다. 이 절은 아래의 초기
+조사 결론보다 최신이며, 아직 production 또는 release readiness를 주장하지 않는다.
+
+- 고정 FCS commit: `ed2cd7049c4d84d9e2ccb3eb55245ea712b040f1`
+- 목표 Sharlayan package: `9.2.0`
+- 목표 IronworksTranslator package: `1.3.0-beta.4`
+- 2026-07-26 사용자 결정으로 재현 가능한 장면을 찾지 못한 `TalkSubtitle`은 이번
+  release에서 제외하고 후속 조사로 돌렸다.
+- Hermes v2는 기존 세 resource를 필수로 유지하고 `battleTalk`를 optional로 확장한다.
+- exact FCS assembly에서 addon, UI array, AgentHUD queue layout을 추출하는 deterministic
+  probe/generator 경로를 구현했다.
+
+실게임 BattleTalk spike에서 확인한 current-visible 계약:
+
+- `_BattleTalk` addon visibility와 BattleTalk NumberArray index 0의 zero/nonzero 상태가
+  화면 열림/닫힘과 일치했다.
+- NumberArray index 0은 boolean이 아니며 관찰한 style에 따라 여러 nonzero 값을 사용했다.
+- BattleTalk StringArray index 0은 name, index 1은 text와 일치했다.
+- 빠른 직접 교체에서는 addon visibility가 유지된 채 StringArray text가 다음 값으로
+  교체됐다.
+- AgentHUD queue는 다음 항목의 pending 순서를 진단하는 데 유용했지만 current-visible
+  runtime source로 사용하지 않는다.
+- addon AtkValues에는 current name/text 계약으로 사용할 값이 없었다.
+- NumberArray/StringArray `UpdateState`는 한 frame 수준으로 사라질 수 있어 sequence ID로
+  사용하지 않는다.
+
+Sharlayan candidate API 실게임 결과:
+
+- hidden baseline은 `IsAvailable=true`, `IsVisible=false`로 관찰됐다.
+- 빠른 교체 중 혼합 snapshot은 transient `IsAvailable=false`가 되었고, 다음 stable
+  name/text에서 `Sequence`가 증가했다.
+- close/reopen과 서로 다른 연속 text에서 Sequence가 단조 증가했다.
+- 180초 correlation 관찰에서 7개 표시 event를 읽었고, 같은 3개 발화 묶음이 다시
+  나타났을 때도 새 `Sequence` 범위로 증가했다.
+- BattleTalk-only 후보의 후속 관찰에서는 동일 speaker/text가 중간의 안정적인 hidden
+  상태를 경계로 연속 재표시됐고 `Sequence`가 4에서 5로 증가했다. raw addon visibility와
+  NumberArray state도 같은 close/reopen 경계를 보였다.
+- visible 상태를 유지한 채 완전히 동일한 speaker/text로 직접 교체되는 경우는 관찰하지
+  못했으므로 지원 증거는 visibility generation 또는 content change가 있는 실제 관찰
+  형태로 한정한다.
+- style 7 variant의 빠른 직접 교체에서는 queue에 다음 text가 pending으로 나타난 뒤
+  addon visibility를 유지한 채 StringArray text가 교체됐고 public `Sequence`가 8에서
+  9로 증가했다. queue는 이 상관관계의 진단 증거로만 사용하며 runtime source는 UI
+  arrays와 addon visibility로 유지한다.
+- 같은 관찰 구간의 CHATLOG에는 BattleTalk와 관련된 `NPCDialog`/`BossQuotes` 항목이
+  없었다. 이는 해당 구간의 중복 부재 증거이며 전체 event 종류의 중복 부재를 뜻하지 않는다.
+- 별도 300초 TalkSubtitle 관찰에서는 addon visibility가 두 차례 전환됐지만 text는
+  계속 비어 있었다. hidden/empty lifecycle 증거로만 기록하며 화면 text 일치 PASS로
+  판정하지 않는다.
+- 숫자형 CHATLOG code 판별 관찰에서 대사 항목이 별도로 나타났지만 당시 BattleTalk
+  text와 상관되지 않았다. source 간 text-only 중복 제거는 계속 도입하지 않는다.
+- BattleTalk-only Sharlayan 9.2.0 local package를 독립 NuGet cache에서 소비해
+  `1.3.0-beta.4` single-file publish를 만들었고, 임시 EXE는 `DialogueWindow`와 WatchDog를
+  시작한 뒤 정상 종료됐다. 이 시점의 Hermes production에는 아직 BattleTalk resource가
+  없으므로 packaged startup PASS이며 packaged BattleTalk 활성화 PASS는 아니다.
+- 실제 이름과 문장은 repository 문서, commit 및 영구 로그에 기록하지 않았다.
+
+현재 남은 BattleTalk release gate:
+
+- reconnect, CHATLOG `NPCDialog`/`BossQuotes` event correlation
+- Hermes production 승격, Sharlayan 9.2.0 package publish/fresh-cache restore
+- IronworksTranslator packaged Release 및 beta.3→beta.4 update/restart
+
+위 gate가 끝나기 전에는 Hermes production, NuGet 및 `1.3.0-beta.4`를 게시하지 않는다.
+
 ## 1. 조사 목적
 
 이 문서는 IronworksTranslator의 Hermes v2 마이그레이션 이후 `BattleTalk`와

--- a/src/IronworksTranslator/IronworksTranslator.csproj
+++ b/src/IronworksTranslator/IronworksTranslator.csproj
@@ -82,7 +82,7 @@
     <PackageReference Include="PuppeteerSharp" Version="20.2.6" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="Sharlayan.Lite" Version="9.1.4" />
+    <PackageReference Include="Sharlayan.Lite" Version="9.2.0" />
     <PackageReference Include="System.Management" Version="10.0.9" />
     <PackageReference Include="WPF-UI" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />

--- a/src/IronworksTranslator/Models/DialogueEntry.cs
+++ b/src/IronworksTranslator/Models/DialogueEntry.cs
@@ -1,14 +1,19 @@
+using IronworksTranslator.Models.Enums;
+
 namespace IronworksTranslator.Models
 {
     public sealed class DialogueEntry
     {
-        public DialogueEntry(string? speaker, string text)
+        public DialogueEntry(DialogueKind kind, string? speaker, string text)
         {
             ArgumentNullException.ThrowIfNull(text);
 
+            Kind = kind;
             Speaker = speaker ?? string.Empty;
             Text = text;
         }
+
+        public DialogueKind Kind { get; }
 
         public string Speaker { get; }
 

--- a/src/IronworksTranslator/Models/Enums/DialogueKind.cs
+++ b/src/IronworksTranslator/Models/Enums/DialogueKind.cs
@@ -1,0 +1,9 @@
+namespace IronworksTranslator.Models.Enums
+{
+    public enum DialogueKind
+    {
+        ChatLog,
+        StandardTalk,
+        BattleTalk,
+    }
+}

--- a/src/IronworksTranslator/Services/FFXIV/ChatLookupService.cs
+++ b/src/IronworksTranslator/Services/FFXIV/ChatLookupService.cs
@@ -157,28 +157,15 @@ namespace IronworksTranslator.Services.FFXIV
             try
             {
                 var handler = CurrentMemoryHandler;
-                if (handler?.Reader.CanGetTalk() != true)
+                if (handler == null)
                 {
                     LogTalkNotReady();
                     return;
                 }
 
                 _talkUnavailableLogged = false;
-                TalkResult talk = handler.Reader.GetTalk();
-                if (!_talkObservationTracker.ShouldEnqueue(talk))
-                {
-                    return;
-                }
-
-                var dialogueEntry = new DialogueEntry(talk.Name, talk.Text);
-                ChatQueue.EnqueueDialogue(dialogueEntry);
-                Log.Debug(
-                    "Enqueued Talk observation. Source: {TalkSource}, Visible: {IsVisible}, " +
-                    "Speaker length: {SpeakerLength}, Text length: {TextLength}",
-                    talk.Source,
-                    talk.IsVisible,
-                    dialogueEntry.Speaker.Length,
-                    dialogueEntry.Text.Length);
+                PollStandardTalk(handler);
+                PollBattleTalk(handler);
             }
             catch (System.ComponentModel.Win32Exception)
             {
@@ -189,6 +176,81 @@ namespace IronworksTranslator.Services.FFXIV
             {
                 Log.Error(ex, "Error in UpdateDialogue timer callback");
             }
+        }
+
+        private void PollStandardTalk(MemoryHandler handler)
+        {
+            if (!handler.Reader.CanGetCurrentTalk())
+            {
+                return;
+            }
+
+            try
+            {
+                TalkResult talk = handler.Reader.GetCurrentTalk();
+                if (!_talkObservationTracker.ShouldEnqueue(talk))
+                {
+                    return;
+                }
+
+                EnqueueDialogue(DialogueKind.StandardTalk, talk.Name, talk.Text);
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "StandardTalk polling failed; other dialogue sources will continue.");
+            }
+        }
+
+        private void PollBattleTalk(MemoryHandler handler)
+        {
+            if (!handler.Reader.CanGetBattleTalk())
+            {
+                return;
+            }
+
+            try
+            {
+                BattleTalkResult battleTalk = handler.Reader.GetBattleTalk();
+                if (!_talkObservationTracker.ShouldEnqueue(battleTalk))
+                {
+                    return;
+                }
+
+                EnqueueDialogue(
+                    DialogueKind.BattleTalk,
+                    battleTalk.Name,
+                    battleTalk.Text,
+                    battleTalk.Sequence);
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "BattleTalk polling failed; other dialogue sources will continue.");
+            }
+        }
+
+        private static void EnqueueDialogue(
+            DialogueKind kind,
+            string? speaker,
+            string text,
+            long? sequence = null)
+        {
+            var dialogueEntry = new DialogueEntry(kind, speaker, text);
+            ChatQueue.EnqueueDialogue(dialogueEntry);
+            Log.Debug(
+                "Enqueued dialogue observation. Kind: {DialogueKind}, Sequence: {Sequence}, " +
+                "Speaker length: {SpeakerLength}, Text length: {TextLength}",
+                kind,
+                sequence,
+                dialogueEntry.Speaker.Length,
+                dialogueEntry.Text.Length);
         }
 
         [TraceMethod]
@@ -280,7 +342,10 @@ namespace IronworksTranslator.Services.FFXIV
         private void EnsureDialogueTimerStartedIfReady()
         {
             var handler = CurrentMemoryHandler;
-            if (handler?.Reader.CanGetTalk() != true)
+            if (handler == null
+                || !HasAnyDialogueCapability(
+                    handler.Reader.CanGetCurrentTalk(),
+                    handler.Reader.CanGetBattleTalk()))
             {
                 LogTalkNotReady();
                 return;
@@ -298,6 +363,13 @@ namespace IronworksTranslator.Services.FFXIV
             }
         }
 
+        internal static bool HasAnyDialogueCapability(
+            bool standardTalk,
+            bool battleTalk)
+        {
+            return standardTalk || battleTalk;
+        }
+
         private void OnMemoryLocationsFound(
             object sender,
             ConcurrentDictionary<string, MemoryLocation> memoryLocations,
@@ -310,12 +382,15 @@ namespace IronworksTranslator.Services.FFXIV
 
             LogResourceDiagnosticsOnce(handler);
             var hasChatLog = memoryLocations.ContainsKey(Signatures.CHATLOG_KEY);
-            var hasTalk = handler.Reader.CanGetTalk();
+            var hasTalk = handler.Reader.CanGetCurrentTalk();
+            var hasBattleTalk = handler.Reader.CanGetBattleTalk();
             Log.Information(
-                "Sharlayan memory locations resolved in {ProcessingTime} ms. CHATLOG: {HasChatLog}, Talk: {HasTalk}",
+                "Sharlayan memory locations resolved in {ProcessingTime} ms. CHATLOG: {HasChatLog}, " +
+                "StandardTalk: {HasTalk}, BattleTalk: {HasBattleTalk}",
                 processingTime,
                 hasChatLog,
-                hasTalk);
+                hasTalk,
+                hasBattleTalk);
 
             lock (_timerLock)
             {

--- a/src/IronworksTranslator/Services/FFXIV/TalkObservationTracker.cs
+++ b/src/IronworksTranslator/Services/FFXIV/TalkObservationTracker.cs
@@ -9,6 +9,8 @@ namespace IronworksTranslator.Services.FFXIV
         private bool _wasCurrentVisible;
         private string _speaker = string.Empty;
         private string _text = string.Empty;
+        private bool _hasBattleSequence;
+        private long _battleSequence;
 
         public bool ShouldEnqueue(TalkResult snapshot)
         {
@@ -42,6 +44,30 @@ namespace IronworksTranslator.Services.FFXIV
             }
         }
 
+        public bool ShouldEnqueue(BattleTalkResult snapshot)
+        {
+            ArgumentNullException.ThrowIfNull(snapshot);
+
+            lock (_syncRoot)
+            {
+                if (!snapshot.IsAvailable
+                    || !snapshot.IsVisible
+                    || string.IsNullOrEmpty(snapshot.Text))
+                {
+                    return false;
+                }
+
+                if (_hasBattleSequence && snapshot.Sequence == _battleSequence)
+                {
+                    return false;
+                }
+
+                _hasBattleSequence = true;
+                _battleSequence = snapshot.Sequence;
+                return true;
+            }
+        }
+
         public void Reset()
         {
             lock (_syncRoot)
@@ -50,6 +76,8 @@ namespace IronworksTranslator.Services.FFXIV
                 _wasCurrentVisible = false;
                 _speaker = string.Empty;
                 _text = string.Empty;
+                _hasBattleSequence = false;
+                _battleSequence = 0;
             }
         }
     }

--- a/src/IronworksTranslator/ViewModels/Windows/ChatWindowViewModel.cs
+++ b/src/IronworksTranslator/ViewModels/Windows/ChatWindowViewModel.cs
@@ -522,7 +522,7 @@ namespace IronworksTranslator.ViewModels.Windows
             ArgumentNullException.ThrowIfNull(translation);
 
             return translation.TranslatedText is string translatedText
-                ? new DialogueEntry(translation.Author, translatedText)
+                ? new DialogueEntry(DialogueKind.ChatLog, translation.Author, translatedText)
                 : null;
         }
 

--- a/tests/IronworksTranslator.Tests/Models/ChatQueueTests.cs
+++ b/tests/IronworksTranslator.Tests/Models/ChatQueueTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using IronworksTranslator.Models;
+using IronworksTranslator.Models.Enums;
 using Sharlayan.Core;
 
 namespace IronworksTranslator.Tests.Models;
@@ -15,18 +16,19 @@ public class ChatQueueTests
     [Fact]
     public void EnqueueDialogue_PreservesSpeakerAndText()
     {
-        ChatQueue.EnqueueDialogue(new DialogueEntry("Alphinaud", "First message"));
+        ChatQueue.EnqueueDialogue(new DialogueEntry(DialogueKind.StandardTalk, "Alphinaud", "First message"));
 
         Assert.True(ChatQueue.TryDequeueDialogue(out var queued));
         Assert.NotNull(queued);
         Assert.Equal("Alphinaud", queued.Speaker);
         Assert.Equal("First message", queued.Text);
+        Assert.Equal(DialogueKind.StandardTalk, queued.Kind);
     }
 
     [Fact]
     public void EnqueueDialogue_NormalizesNullSpeaker()
     {
-        ChatQueue.EnqueueDialogue(new DialogueEntry(null, "Narration"));
+        ChatQueue.EnqueueDialogue(new DialogueEntry(DialogueKind.BattleTalk, null, "Narration"));
 
         Assert.True(ChatQueue.TryDequeueDialogue(out var queued));
         Assert.NotNull(queued);
@@ -37,8 +39,8 @@ public class ChatQueueTests
     [Fact]
     public void EnqueueDialogue_PreservesSameTextFromDifferentSpeakers()
     {
-        ChatQueue.EnqueueDialogue(new DialogueEntry("Alphinaud", "Same"));
-        ChatQueue.EnqueueDialogue(new DialogueEntry("Tataru", "Same"));
+        ChatQueue.EnqueueDialogue(new DialogueEntry(DialogueKind.StandardTalk, "Alphinaud", "Same"));
+        ChatQueue.EnqueueDialogue(new DialogueEntry(DialogueKind.BattleTalk, "Tataru", "Same"));
 
         Assert.True(ChatQueue.TryDequeueDialogue(out var first));
         Assert.True(ChatQueue.TryDequeueDialogue(out var second));
@@ -46,6 +48,8 @@ public class ChatQueueTests
         Assert.NotNull(second);
         Assert.Equal("Alphinaud", first.Speaker);
         Assert.Equal("Tataru", second.Speaker);
+        Assert.Equal(DialogueKind.StandardTalk, first.Kind);
+        Assert.Equal(DialogueKind.BattleTalk, second.Kind);
     }
 
     [Fact]
@@ -59,7 +63,8 @@ public class ChatQueueTests
     {
         for (var i = 0; i < 105; i++)
         {
-            ChatQueue.EnqueueDialogue(new DialogueEntry($"Speaker {i}", $"Message {i}"));
+            ChatQueue.EnqueueDialogue(
+                new DialogueEntry(DialogueKind.StandardTalk, $"Speaker {i}", $"Message {i}"));
         }
 
         Assert.Equal(100, ChatQueue.rq.Count);

--- a/tests/IronworksTranslator.Tests/Services/FFXIV/ChatLookupServiceTests.cs
+++ b/tests/IronworksTranslator.Tests/Services/FFXIV/ChatLookupServiceTests.cs
@@ -1,0 +1,26 @@
+using IronworksTranslator.Services.FFXIV;
+
+namespace IronworksTranslator.Tests.Services.FFXIV;
+
+public class ChatLookupServiceTests
+{
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public void HasAnyDialogueCapability_StartsForEachIndependentSource(
+        bool standardTalk,
+        bool battleTalk)
+    {
+        Assert.True(
+            ChatLookupService.HasAnyDialogueCapability(
+                standardTalk,
+                battleTalk));
+    }
+
+    [Fact]
+    public void HasAnyDialogueCapability_StopsWhenNoSourceIsReady()
+    {
+        Assert.False(ChatLookupService.HasAnyDialogueCapability(false, false));
+    }
+}

--- a/tests/IronworksTranslator.Tests/Services/FFXIV/TalkObservationTrackerTests.cs
+++ b/tests/IronworksTranslator.Tests/Services/FFXIV/TalkObservationTrackerTests.cs
@@ -82,6 +82,31 @@ public class TalkObservationTrackerTests
         Assert.True(_tracker.ShouldEnqueue(Current("アルフィノ", "어서 와! 👋")));
     }
 
+    [Fact]
+    public void BattleTalk_UsesSequenceEvenWhenPairIsIdentical()
+    {
+        Assert.True(_tracker.ShouldEnqueue(new BattleTalkResult(true, true, "Voice", "Fear.", 10)));
+        Assert.False(_tracker.ShouldEnqueue(new BattleTalkResult(true, true, "Voice", "Fear.", 10)));
+        Assert.True(_tracker.ShouldEnqueue(new BattleTalkResult(true, true, "Voice", "Fear.", 11)));
+    }
+
+    [Fact]
+    public void DialogueSources_KeepIndependentBaselines()
+    {
+        Assert.True(_tracker.ShouldEnqueue(Current("Voice", "Same")));
+        Assert.True(_tracker.ShouldEnqueue(new BattleTalkResult(true, true, "Voice", "Same", 1)));
+    }
+
+    [Fact]
+    public void Reset_ClearsAllSourceBaselines()
+    {
+        Assert.True(_tracker.ShouldEnqueue(new BattleTalkResult(true, true, "Voice", "Same", 1)));
+
+        _tracker.Reset();
+
+        Assert.True(_tracker.ShouldEnqueue(new BattleTalkResult(true, true, "Voice", "Same", 1)));
+    }
+
     private static TalkResult Current(string speaker, string text)
     {
         return new TalkResult(true, speaker, text, TalkSource.Current, true);

--- a/tests/IronworksTranslator.Tests/ViewModels/ChatWindowViewModelHelperTests.cs
+++ b/tests/IronworksTranslator.Tests/ViewModels/ChatWindowViewModelHelperTests.cs
@@ -121,6 +121,7 @@ public class ChatWindowViewModelHelperTests
         var entry = ChatWindowViewModel.CreateDialogueEntry(translation);
 
         Assert.NotNull(entry);
+        Assert.Equal(DialogueKind.ChatLog, entry.Kind);
         Assert.Equal("Alphinaud", entry.Speaker);
         Assert.Equal("어서 와.", entry.Text);
     }


### PR DESCRIPTION
## Summary

- preserve dialogue source through a required `DialogueKind`
- poll StandardTalk and BattleTalk independently from one dialogue timer
- isolate per-source failures and deduplicate BattleTalk by `Sequence`
- render BattleTalk as `Speaker: translated text` without translating the speaker
- update the investigation and release checklist

TalkSubtitle is deferred because no reproducible live scene was available.

## Validation

- Release build passed with zero warnings/errors
- 160 tests passed
- fresh-cache restore/build/test passed against the local BattleTalk-only Sharlayan.Lite 9.2.0 package
- `1.3.0-beta.4` single-file publish succeeded
- temporary packaged app opened a responsive DialogueWindow and started WatchDog, then closed normally
- packaged BattleTalk activation remains gated on Hermes production promotion and the final Sharlayan package