### PR TITLE
Update Sharlayan.Lite to 9.2.1

### DIFF
--- a/UPDATE-TEST-CHECKLIST.md
+++ b/UPDATE-TEST-CHECKLIST.md
@@ -238,12 +238,13 @@ Sharlayan upstream smoke는 IronworksTranslator의 release readiness를 대신�
 
 Package and resource checks:
 
-- [ ] Restore 결과와 publish 산출물이 `Sharlayan.Lite 9.2.0`을 사용한다.
+- [ ] Restore 결과와 publish 산출물이 `Sharlayan.Lite 9.2.1`을 사용한다.
 - [ ] Publish 및 Velopack package에 `FFXIVClientStructs`, `HermesAddress`,
   `latest/address.json`, local `address.json` 또는 `UseInternalAddress` consumer가 없다.
-- [ ] 새 Hermes cache에서 앱을 시작하면 `RemotePreferred`가 remote
-  `live-verified` revision을 선택하고 source와 revision을 진단 로그에 남긴다.
-- [ ] 기존 verified cache를 보존한 상태로 remote를 사용할 수 없게 만들면 cache fallback으로
+- [ ] 새 Hermes cache에서 앱을 시작하면 `RemotePreferred`가 remote `generated` 또는
+  기존 `live-verified` revision을 선택하고 source, revision, validation status를 진단 로그에
+  남긴다.
+- [ ] 기존 valid cache를 보존한 상태로 remote를 사용할 수 없게 만들면 cache fallback으로
   앱이 시작되고 CHATLOG와 Talk가 계속 동작한다.
 - [ ] 별도의 깨끗한 cache에서 remote를 사용할 수 없게 만들면 embedded fallback으로 앱이
   시작되고 CHATLOG와 Talk가 계속 동작한다.

--- a/src/IronworksTranslator/IronworksTranslator.csproj
+++ b/src/IronworksTranslator/IronworksTranslator.csproj
@@ -82,7 +82,7 @@
     <PackageReference Include="PuppeteerSharp" Version="20.2.6" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="Sharlayan.Lite" Version="9.2.0" />
+    <PackageReference Include="Sharlayan.Lite" Version="9.2.1" />
     <PackageReference Include="System.Management" Version="10.0.9" />
     <PackageReference Include="WPF-UI" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />


### PR DESCRIPTION
## Summary
- update IronworksTranslator to Sharlayan.Lite 9.2.1
- document generated and historic live-verified Hermes validation states in the release checklist
- use valid-cache terminology for remote fallback

## Impact
Sharlayan.Lite 9.2.1 accepts CI-generated Hermes v2 manifests while older clients continue to fall back safely.

## Validation
- official NuGet-only restore in a new dedicated package cache
- .nupkg.metadata source is https://api.nuget.org/v3/index.json
- metadata content hash matches project.assets.json
- Sharlayan DLL SHA-256: c0fd1bca857d1f238acb720fc0337c0dcbac35406c42d8932285d2f18270148
- Sharlayan product version: 9.2.1+2d3e0364fac90575f398508467cdb6c5db424dd1
- Release solution build: 0 warnings, 0 errors
- tests: 176/176 passed